### PR TITLE
Fix output tensor dimension consistency.

### DIFF
--- a/rexnetv1.py
+++ b/rexnetv1.py
@@ -179,7 +179,7 @@ class ReXNetV1(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
-        x = self.output(x).squeeze()
+        x = self.output(x).flatten(1)
         return x
 
 

--- a/rexnetv1_lite.py
+++ b/rexnetv1_lite.py
@@ -135,7 +135,7 @@ class ReXNetV1_lite(nn.Module):
     def forward(self, x):
         x = self.features(x)
         x = self.avgpool(x)
-        x = self.output(x).squeeze()
+        x = self.output(x).flatten(1)
         return x
 
 if __name__ == '__main__':
@@ -144,3 +144,4 @@ if __name__ == '__main__':
     loss = out.sum()
     loss.backward()
     print('Checked a single forward/backward iteration')
+


### PR DESCRIPTION
For a single input, e.g. 1x3x224x224, the `squeeze`  function also removes the batch dimension.
So, it would be better to use `flatten` to keep the same output dimensions as the batch inference.